### PR TITLE
Add tower support for ServedDir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -1107,6 +1107,7 @@ dependencies = [
  "sync_wrapper",
  "tempfile",
  "tokio",
+ "tower 0.4.13",
  "winapi",
 ]
 
@@ -1258,6 +1259,17 @@ dependencies = [
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -1289,7 +1301,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -1312,6 +1324,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.88"
 
 [features]
 mime_guess = ["dep:mime_guess"]
+tower = ["dep:tower"]
 
 
 [package.metadata.docs.rs]
@@ -32,6 +33,7 @@ rapidhash = "4.2"
 sync_wrapper = "1.0"
 tokio = { version = "1.49", features = ["rt-multi-thread"] }
 mime_guess = { version = "2.0", optional = true }
+tower = { version = "0.4", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.6", features = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,9 @@ impl From<IOError> for ServeFilesError {
 mod body;
 
 pub mod served_dir;
+#[cfg(feature = "tower")]
+/// Tower Service integration.
+pub mod tower;
 
 mod compression;
 mod etag;

--- a/src/served_dir.rs
+++ b/src/served_dir.rs
@@ -376,6 +376,14 @@ impl Node {
     }
 }
 
+#[cfg(feature = "tower")]
+impl ServedDir {
+    /// Converts this `ServedDir` into a `tower::Service`.
+    pub fn into_tower_service(self) -> crate::tower::ServedDirService {
+        crate::tower::ServedDirService::new(self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -588,4 +596,5 @@ mod tests {
         assert_eq!(e.header(&header::ACCESS_CONTROL_ALLOW_ORIGIN).unwrap(), "*");
         assert_eq!(e.header(&header::CONTENT_TYPE).unwrap(), "text/plain");
     }
+
 }

--- a/src/tower.rs
+++ b/src/tower.rs
@@ -1,0 +1,122 @@
+use crate::served_dir::ServedDir;
+use crate::{BoxError, ServeFilesError};
+use bytes::Bytes;
+use http::HeaderValue;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tower::Service;
+use std::future::Future;
+use std::pin::Pin;
+
+/// A tower service that serves files from a directory.
+#[derive(Clone)]
+pub struct ServedDirService {
+    inner: Arc<ServedDir>,
+}
+
+impl ServedDirService {
+    pub(crate) fn new(served_dir: ServedDir) -> Self {
+        Self {
+            inner: Arc::new(served_dir),
+        }
+    }
+}
+
+impl<B> Service<http::Request<B>> for ServedDirService
+where
+    B: Send + Sync + 'static,
+{
+    type Response = http::Response<
+        Box<dyn http_body::Body<Data = Bytes, Error = BoxError> + Send + Sync + Unpin>,
+    >;
+    type Error = std::convert::Infallible;
+    type Future = Pin<
+        Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + Sync>,
+    >;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: http::Request<B>) -> Self::Future {
+        let inner = self.inner.clone();
+        Box::pin(async move {
+            let (parts, _) = req.into_parts();
+            let req = http::Request::from_parts(parts, ());
+            let path = req.uri().path();
+            let path = path.strip_prefix('/').unwrap_or(path);
+
+            match inner.get(path, req.headers()).await {
+                Ok(entity) => {
+                    let resp = crate::serve(entity, &req);
+                    let (parts, body) = resp.into_parts();
+                    let boxed_body: Box<
+                        dyn http_body::Body<Data = Bytes, Error = BoxError> + Send + Sync + Unpin,
+                    > = Box::new(body);
+                    Ok(http::Response::from_parts(parts, boxed_body))
+                }
+                Err(e) => {
+                    let status = match e {
+                        ServeFilesError::NotFound => http::StatusCode::NOT_FOUND,
+                        ServeFilesError::InvalidPath(_) => http::StatusCode::BAD_REQUEST,
+                        ServeFilesError::NotAFile(_) => http::StatusCode::NOT_FOUND,
+                        ServeFilesError::NotADirectory(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
+                        ServeFilesError::IOError(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
+                    };
+                    let body_str = e.to_string();
+                    let body = crate::Body::from(body_str);
+                    let boxed_body: Box<
+                        dyn http_body::Body<Data = Bytes, Error = BoxError> + Send + Sync + Unpin,
+                    > = Box::new(body);
+
+                    let mut res = http::Response::new(boxed_body);
+                    *res.status_mut() = status;
+                    res.headers_mut().insert(
+                        http::header::CONTENT_TYPE,
+                        HeaderValue::from_static("text/plain"),
+                    );
+                    Ok(res)
+                }
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::served_dir::ServedDir;
+    use http_body_util::BodyExt;
+    use tempfile::TempDir;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_tower_service() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        std::fs::write(path.join("index.html"), "Hello, World!").unwrap();
+
+        let served_dir = ServedDir::builder(path).unwrap().build();
+        let mut service = ServedDirService::new(served_dir);
+
+        let req = http::Request::builder()
+            .uri("http://localhost/index.html")
+            .body(())
+            .unwrap();
+
+        let resp = service.call(req).await.unwrap();
+
+        assert_eq!(resp.status(), http::StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(http::header::CONTENT_TYPE).unwrap(),
+            "text/html"
+        );
+
+        let body = resp.into_body();
+        let collected = BodyExt::collect(body).await.unwrap();
+        let bytes = collected.to_bytes();
+        assert_eq!(bytes, "Hello, World!");
+    }
+}


### PR DESCRIPTION
Added optional support for converting a `ServedDir` into a `tower::Service`. This allows integration with the tower ecosystem. The feature is enabled by the `tower` feature flag. The implementation resides in `src/tower.rs` and `ServedDir` has a convenience method `into_tower_service`.

---
*PR created automatically by Jules for task [17381880347376946595](https://jules.google.com/task/17381880347376946595) started by @StupendousYappi*