### PR TITLE
Add tower::Service support for ServedDir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,7 +1138,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -1270,6 +1270,7 @@ dependencies = [
  "sync_wrapper",
  "tempfile",
  "tokio",
+ "tower 0.4.13",
  "winapi",
 ]
 
@@ -1421,6 +1422,17 @@ dependencies = [
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -1452,7 +1464,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -1475,6 +1487,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.91"
 [features]
 mime_guess = ["dep:mime_guess"]
 runtime-compression = ["dep:brotli", "dep:tempfile"]
+tower = ["dep:tower", "dep:http-body-util"]
 
 
 [package.metadata.docs.rs]
@@ -36,6 +37,8 @@ mime_guess = { version = "2.0", optional = true }
 brotli = { version = "7.0", optional = true }
 tempfile = { version = "3.11", optional = true }
 log = { version = "0.4.29", features = ["std"] }
+tower = { version = "0.4", optional = true }
+http-body-util = { version = "0.1", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.6", features = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,10 @@ mod body;
 
 pub mod served_dir;
 
+#[cfg(feature = "tower")]
+/// Tower service integration.
+pub mod tower;
+
 #[cfg(feature = "runtime-compression")]
 mod brotli_cache;
 mod compression;

--- a/src/served_dir.rs
+++ b/src/served_dir.rs
@@ -8,6 +8,8 @@ use crate::compression::{CompressionStrategy, CompressionSupport, MatchedFile};
 
 #[cfg(feature = "runtime-compression")]
 use crate::brotli_cache::BrotliCache;
+#[cfg(feature = "tower")]
+use crate::tower::ServedDirService;
 
 use crate::{FileEntity, ServeFilesError};
 use bytes::Bytes;
@@ -305,6 +307,12 @@ impl ServedDirBuilder {
     pub fn common_header(mut self, name: header::HeaderName, value: HeaderValue) -> Self {
         self.common_headers.insert(name, value);
         self
+    }
+
+    /// Builds a tower service from the `ServedDirBuilder`.
+    #[cfg(feature = "tower")]
+    pub fn build_tower_service(self) -> ServedDirService {
+        ServedDirService::new(self.build())
     }
 
     /// Builds the [`ServedDir`].

--- a/src/tower.rs
+++ b/src/tower.rs
@@ -1,0 +1,113 @@
+use crate::served_dir::ServedDir;
+use crate::ServeFilesError;
+use http::{Request, Response, StatusCode};
+use http_body::Body;
+use std::convert::Infallible;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tower::Service;
+
+/// A Tower service that serves files from a [`ServedDir`].
+#[derive(Clone)]
+pub struct ServedDirService(Arc<ServedDir>);
+
+impl ServedDirService {
+    pub(crate) fn new(served_dir: ServedDir) -> Self {
+        Self(Arc::new(served_dir))
+    }
+}
+
+type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+type BoxBody = Box<dyn Body<Data = bytes::Bytes, Error = Box<dyn std::error::Error + Send + Sync>> + Send + Sync + Unpin>;
+
+impl<B> Service<Request<B>> for ServedDirService
+where
+    B: Send + 'static,
+{
+    type Response = Response<BoxBody>;
+    type Error = Infallible;
+    type Future = BoxFuture<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        let served_dir = self.0.clone();
+        Box::pin(async move {
+            // We ignore the request body as we are serving static files.
+            let (parts, _body) = req.into_parts();
+            let req = Request::from_parts(parts, ());
+            let path = req.uri().path();
+
+            // ServedDir::get expects the path to be relative to the served directory,
+            // but req.uri().path() is absolute. However, ServedDir::get handles
+            // strip_prefix if configured.
+            // Also ServedDir::validate_path checks for absolute path if it starts with /.
+            // Wait, ServedDir::get implementation:
+            // if path == prefix => ".", prefix removal...
+            // validate_path checks if path is absolute: `if path.as_bytes().first() == Some(&b'/')`.
+            // Request URI path usually starts with /.
+            // So we might need to strip the leading slash?
+            // Let's check ServedDir::get again.
+            // "This method will return an error with kind `ErrorKind::InvalidInput` if the path is invalid."
+            // In `src/served_dir.rs`:
+            // fn validate_path(&self, path: &str) ...
+            // if path.as_bytes().first() == Some(&b'/') { return Err(... "path is absolute") }
+            // So ServedDir::get expects a relative path!
+            // But Request URI path is absolute (starts with /).
+            // So we MUST strip the leading slash.
+
+            let path = if let Some(p) = path.strip_prefix('/') {
+                p
+            } else {
+                path
+            };
+
+            // Handle root path "" -> "." for served_dir if needed?
+            // If path was "/", it becomes "".
+            // ServedDir::get: `match self.strip_prefix ...`.
+            // `validate_path` checks `..`.
+            // If path is empty, what happens? `validate_path` is fine.
+            // `full_path = self.dirpath.join(path)`. join("") is same dir.
+            // `find_file` calls `File::open`. `dirpath` is a directory.
+            // `find_file` checks metadata. If dir, returns IsDirectory.
+            // If `append_index_html` is true, it appends index.html.
+            // So empty path ("") should work if it maps to the directory and index.html logic applies.
+
+            match served_dir.get(path, req.headers()).await {
+                Ok(entity) => {
+                    let resp = crate::serving::serve(entity, &req);
+                    let (parts, body) = resp.into_parts();
+
+                    // Map the body error to Box<dyn Error + Send + Sync>
+                    use http_body_util::BodyExt;
+                    let boxed_body: BoxBody = Box::new(body
+                        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>));
+
+                    Ok(Response::from_parts(parts, boxed_body))
+                },
+                Err(e) => {
+                    let status = match e {
+                        ServeFilesError::NotFound => StatusCode::NOT_FOUND,
+                        ServeFilesError::IsDirectory(_) => StatusCode::NOT_FOUND,
+                        ServeFilesError::InvalidPath(_) => StatusCode::BAD_REQUEST,
+                        ServeFilesError::ConfigError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+                        ServeFilesError::CompressionError(_, _) => StatusCode::INTERNAL_SERVER_ERROR,
+                        ServeFilesError::IOError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+                    };
+
+                    let body_content = e.to_string();
+                    use http_body_util::BodyExt;
+                    let body = http_body_util::Full::new(bytes::Bytes::from(body_content))
+                        .map_err(|_: Infallible| unreachable!());
+                    let boxed_body: BoxBody = Box::new(body);
+
+                    Ok(Response::builder().status(status).body(boxed_body).unwrap())
+                }
+            }
+        })
+    }
+}

--- a/tests/tower_test.rs
+++ b/tests/tower_test.rs
@@ -1,0 +1,70 @@
+#![cfg(feature = "tower")]
+
+use http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serve_files::served_dir::ServedDir;
+use tower::Service;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_served_dir_service() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path();
+    std::fs::write(path.join("index.html"), "Hello, world!").unwrap();
+
+    let mut service = ServedDir::builder(path.to_path_buf())
+        .unwrap()
+        .build_tower_service();
+
+    // Successful request
+    let req = Request::builder()
+        .uri("/index.html")
+        .body(())
+        .unwrap();
+
+    let response = service.call(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body();
+    let body_bytes = body.collect().await.unwrap().to_bytes();
+    assert_eq!(body_bytes, "Hello, world!");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_not_found() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path();
+
+    let mut service = ServedDir::builder(path.to_path_buf())
+        .unwrap()
+        .build_tower_service();
+
+    // Not found request
+    let req = Request::builder()
+        .uri("/missing.txt")
+        .body(())
+        .unwrap();
+
+    let response = service.call(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_directory_handling() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path();
+    std::fs::create_dir(path.join("subdir")).unwrap();
+
+    let mut service = ServedDir::builder(path.to_path_buf())
+        .unwrap()
+        .build_tower_service();
+
+    // Directory request -> Should result in 404 (ServedDir::get returns IsDirectory, mapped to 404 in tower.rs)
+    // unless index.html is present and append_index_html is true, but here it is not.
+    let req = Request::builder()
+        .uri("/subdir")
+        .body(())
+        .unwrap();
+
+    let response = service.call(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
Added optional `tower` feature to `serve-files` crate.
Implemented `ServedDirService` which implements `tower::Service`.
Added `build_tower_service` to `ServedDirBuilder`.
Included tests for the new feature.

---
*PR created automatically by Jules for task [11834857714172537369](https://jules.google.com/task/11834857714172537369) started by @StupendousYappi*