### PR TITLE
refactor: change CHUNK_SIZE from static to const

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -26,7 +26,7 @@ use http::{Request, Response, StatusCode};
 
 // This stream breaks apart the file into chunks of at most CHUNK_SIZE. This size is
 // a tradeoff between memory usage and thread handoffs.
-static CHUNK_SIZE: u64 = 65_536;
+const CHUNK_SIZE: u64 = 65_536;
 
 /// HTTP entity created from a [`std::fs::File`] which reads the file chunk-by-chunk within
 /// a [`tokio::task::block_in_place`] closure.


### PR DESCRIPTION
Changes `static CHUNK_SIZE` to `const CHUNK_SIZE` in `src/file.rs`.
This is a code health improvement to use `const` for immutable values.
Verified with `cargo check` and `cargo test`.

---
*PR created automatically by Jules for task [2507887953020884389](https://jules.google.com/task/2507887953020884389) started by @StupendousYappi*