### PR TITLE
⚡ optimize(find_file): avoid unnecessary PathBuf cloning

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -481,7 +481,7 @@ impl CompressionStrategyInner {
 
     pub(crate) fn find_file(
         &self,
-        path: PathBuf,
+        path: &Path,
         supported: crate::compression::CompressionSupport,
     ) -> Result<MatchedFile, SerdirError> {
         match self {
@@ -516,14 +516,14 @@ impl CompressionStrategyInner {
             #[cfg(feature = "runtime-compression")]
             CompressionStrategyInner::Cached(cache) => {
                 if supported.brotli() {
-                    let matched = cache.get(&path)?;
+                    let matched = cache.get(path)?;
                     return Ok(matched);
                 }
             }
             CompressionStrategyInner::None => {}
         }
 
-        Self::try_path(&path, ContentEncoding::Identity)
+        Self::try_path(path, ContentEncoding::Identity)
     }
 
     fn try_path(p: &Path, encoding: ContentEncoding) -> Result<MatchedFile, SerdirError> {

--- a/src/served_dir.rs
+++ b/src/served_dir.rs
@@ -144,15 +144,15 @@ impl ServedDir {
         let full_path = self.dirpath.join(path);
 
         tokio::task::block_in_place(|| {
-            let res = self.find_file(full_path.clone(), preferred);
+            let res = self.find_file(&full_path, preferred);
             let matched_file = match res {
                 Ok(mf) => mf,
                 Err(SerdirError::IsDirectory(_)) if self.append_index_html => {
                     let index_path = full_path.join("index.html");
-                    self.find_file(index_path, preferred)?
+                    self.find_file(&index_path, preferred)?
                 }
                 Err(SerdirError::NotFound(_)) if self.not_found_path.is_some() => {
-                    let not_found_path = self.not_found_path.as_ref().unwrap().clone();
+                    let not_found_path = self.not_found_path.as_ref().unwrap();
                     let matched_file = self.find_file(not_found_path, preferred)?;
                     let entity = self.create_entity(matched_file)?;
                     return Err(SerdirError::NotFound(Some(entity)));
@@ -219,10 +219,10 @@ impl ServedDir {
 
     fn find_file(
         &self,
-        path: impl Into<PathBuf>,
+        path: &Path,
         preferred: CompressionSupport,
     ) -> Result<MatchedFile, SerdirError> {
-        self.compression_strategy.find_file(path.into(), preferred)
+        self.compression_strategy.find_file(path, preferred)
     }
 
     fn calculate_etag(


### PR DESCRIPTION
💡 **What:** The optimization refactors the `find_file` method to accept a `&Path` reference instead of taking ownership of a `PathBuf` or using `impl Into<PathBuf>` which often leads to a `PathBuf` conversion. It also updates all callers to pass references.

🎯 **Why:** Every time `ServedDir::get` was called, it was cloning a `PathBuf` to pass it to `find_file`. This happened at least once per request, and potentially multiple times if directory index appending or custom 404 paths were triggered. By using references, we avoid these unnecessary heap allocations and data copies.

📊 **Measured Improvement:** While a quantitative benchmark was not possible due to environment restrictions (missing dependencies and no internet access), this change is a guaranteed qualitative improvement. It removes at least one `PathBuf` allocation and copy from the primary request handling path, reducing memory pressure and CPU cycles spent on allocation management. This is a common and effective pattern in high-performance Rust code.

---
*PR created automatically by Jules for task [14609037859756829457](https://jules.google.com/task/14609037859756829457) started by @StupendousYappi*