### PR TITLE
🧹 Remove commented-out code in src/brotli_cache.rs

### DIFF
--- a/src/brotli_cache.rs
+++ b/src/brotli_cache.rs
@@ -11,9 +11,6 @@ use std::{
 
 use brotli::enc::backward_references::BrotliEncoderMode;
 use brotli::enc::BrotliEncoderParams;
-// use bytes::Bytes; removed
-// use log::{debug, error, info, warn}; removed
-// use http::HeaderValue; removed
 use sieve_cache::ShardedSieveCache;
 use std::io::Write;
 
@@ -29,8 +26,6 @@ static DEFAULT_TEXT_TYPES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
         "html", "htm", "xhtml", "css", "js", "json", "xml", "svg", "txt", "csv", "tsv", "md",
     ])
 });
-
-// BrotliCacheBuilder removed
 
 /// A service that creates and reuses Brotli-compressed versions of files, returning
 /// a FileEntity for the compressed file if it's supported, or a FileEntity for the


### PR DESCRIPTION
🎯 **What:** Removed commented-out imports and dead code comments from `src/brotli_cache.rs`.
💡 **Why:** Commented-out code serves no purpose and can be confusing to maintainers. Removing it improves code health and readability.
✅ **Verification:** Changes were manually verified by reading the file. A code review confirmed the safety and correctness of the change.
✨ **Result:** A cleaner `src/brotli_cache.rs` file with no distracting dead code.

---
*PR created automatically by Jules for task [4801120908106840302](https://jules.google.com/task/4801120908106840302) started by @StupendousYappi*