### PR TITLE
🧹 remove commented-out code in brotli_cache.rs

### DIFF
--- a/src/brotli_cache.rs
+++ b/src/brotli_cache.rs
@@ -11,9 +11,6 @@ use std::{
 
 use brotli::enc::backward_references::BrotliEncoderMode;
 use brotli::enc::BrotliEncoderParams;
-// use bytes::Bytes; removed
-// use log::{debug, error, info, warn}; removed
-// use http::HeaderValue; removed
 use sieve_cache::ShardedSieveCache;
 use std::io::Write;
 
@@ -29,8 +26,6 @@ static DEFAULT_TEXT_TYPES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
         "html", "htm", "xhtml", "css", "js", "json", "xml", "svg", "txt", "csv", "tsv", "md",
     ])
 });
-
-// BrotliCacheBuilder removed
 
 /// A service that creates and reuses Brotli-compressed versions of files, returning
 /// a FileEntity for the compressed file if it's supported, or a FileEntity for the


### PR DESCRIPTION
Removed commented-out imports and stale 'removed' comments in `src/brotli_cache.rs` to improve code health and maintainability.

---
*PR created automatically by Jules for task [5702515949655253207](https://jules.google.com/task/5702515949655253207) started by @StupendousYappi*