### PR TITLE
🧪 Add unit tests for CompressionStrategy factory methods

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -798,4 +798,45 @@ mod tests {
         let inner = strategy.into_inner();
         assert!(matches!(inner, CompressionStrategyInner::Cached(_)));
     }
+
+    #[test]
+    fn test_compression_strategy_none() {
+        let strategy = CompressionStrategy::none();
+        assert!(matches!(strategy, CompressionStrategy::None));
+
+        let inner = strategy.into_inner();
+        assert!(inner.is_none());
+    }
+
+    #[test]
+    fn test_compression_strategy_default() {
+        let strategy = CompressionStrategy::default();
+        assert!(matches!(strategy, CompressionStrategy::None));
+    }
+
+    #[test]
+    fn test_compression_strategy_static() {
+        let strategy = CompressionStrategy::static_compression();
+        if let CompressionStrategy::Static(static_comp) = strategy {
+            assert!(!static_comp.br);
+            assert!(!static_comp.gzip);
+            assert!(!static_comp.zstd);
+        } else {
+            panic!("expected static compression strategy");
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "runtime-compression")]
+    fn test_compression_strategy_cached() {
+        let strategy = CompressionStrategy::cached_compression();
+        assert!(matches!(strategy, CompressionStrategy::Cached(_)));
+
+        if let CompressionStrategy::Cached(cached) = strategy {
+            assert_eq!(cached.cache_size, 128);
+            assert_eq!(cached.compression_level, BrotliLevel::L5);
+            assert_eq!(cached.max_file_size, 1024 * 1024);
+            assert!(cached.supported_extensions.is_none());
+        }
+    }
 }


### PR DESCRIPTION
This PR addresses the untested `CompressionStrategy` factory methods in `src/compression.rs`.

### 🎯 What:
Added comprehensive unit tests for the following `CompressionStrategy` methods:
- `none()`
- `default()`
- `static_compression()`
- `cached_compression()`

### 📊 Coverage:
The new tests cover:
- Correct enum variant returns for each factory method.
- Correct initialization of the internal structures (e.g., ensuring `static_compression()` really starts with all encodings disabled).
- Default values for `CachedCompression` when created via `cached_compression()`.

### ✨ Result:
Improved test coverage for the core configuration API of the crate, ensuring that the factory methods behave as documented and provide stable defaults.

---
*PR created automatically by Jules for task [3870007859991543940](https://jules.google.com/task/3870007859991543940) started by @StupendousYappi*