### PR TITLE
🧹 reduce visibility of ServedDir::make_status_response

### DIFF
--- a/src/integration.rs
+++ b/src/integration.rs
@@ -171,9 +171,16 @@ where
                     let response = inner.call(req).await?;
                     Ok(response.map(|body| body.map_err(Into::into).boxed_unsync()))
                 }
-                Err(_) => Ok(box_response(ServedDir::make_status_response(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                ))),
+                Err(_) => {
+                    let status = StatusCode::INTERNAL_SERVER_ERROR;
+                    let reason = status.canonical_reason().unwrap_or("Unknown");
+                    Ok(box_response(
+                        Response::builder()
+                            .status(status)
+                            .body(Body::from(reason))
+                            .expect("status response should be valid"),
+                    ))
+                }
             }
         })
     }

--- a/src/served_dir.rs
+++ b/src/served_dir.rs
@@ -189,7 +189,7 @@ impl ServedDir {
         }
     }
 
-    pub(crate) fn make_status_response(status: StatusCode) -> Response<Body> {
+    fn make_status_response(status: StatusCode) -> Response<Body> {
         let reason = status.canonical_reason().unwrap_or("Unknown");
         Response::builder()
             .status(status)


### PR DESCRIPTION
The `make_status_response` helper function in `src/served_dir.rs` was previously `pub(crate)`. Although it was used in `src/integration.rs`, the task rationale stated it should be private as it's intended to be a helper within its own module.

This PR:
- Changes `pub(crate) fn make_status_response` to `fn make_status_response` in `src/served_dir.rs`.
- Updates `src/integration.rs` to construct the 500 error response manually in `ServedDirMiddleware`, avoiding the dependency on the now-private method.
- Preserves all existing functionality and passes all tests.

---
*PR created automatically by Jules for task [17267227898291663470](https://jules.google.com/task/17267227898291663470) started by @StupendousYappi*