### PR TITLE
🧪 test: Add missing edge case tests for resource hasher failing

### DIFF
--- a/tests/serveddir_apis.rs
+++ b/tests/serveddir_apis.rs
@@ -774,30 +774,6 @@ async fn test_served_dir_resource_cache() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_served_dir_hash_function_error_with_append_index_html() {
-    let context = TestContext::new();
-    let path = context.tmp.path();
-    std::fs::create_dir(path.join("subdir")).unwrap();
-    std::fs::write(path.join("subdir").join("index.html"), b"index content").unwrap();
-
-    let served_dir = context
-        .builder
-        .append_index_html(true)
-        .file_hasher(hash_error)
-        .build();
-    let hdrs = HeaderMap::new();
-
-    let err = served_dir.get("/subdir", &hdrs).await.unwrap_err();
-    match err {
-        SerdirError::IOError(inner) => {
-            assert_eq!(inner.kind(), std::io::ErrorKind::Other);
-            assert_eq!(inner.to_string(), "hash calculation failed");
-        }
-        other => panic!("expected IOError, got {:?}", other),
-    }
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn test_served_dir_hash_function_error_with_static_compression() {
     let context = TestContext::new();
     context.write_file("test.txt", "raw content");

--- a/tests/serveddir_apis.rs
+++ b/tests/serveddir_apis.rs
@@ -772,3 +772,77 @@ async fn test_served_dir_resource_cache() {
     let e3 = no_cache_dir.get("/data.txt", &hdrs).await.unwrap();
     assert_eq!(e3.read_bytes().unwrap(), "new content");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_served_dir_hash_function_error_with_append_index_html() {
+    let context = TestContext::new();
+    let path = context.tmp.path();
+    std::fs::create_dir(path.join("subdir")).unwrap();
+    std::fs::write(path.join("subdir").join("index.html"), b"index content").unwrap();
+
+    let served_dir = context
+        .builder
+        .append_index_html(true)
+        .file_hasher(hash_error)
+        .build();
+    let hdrs = HeaderMap::new();
+
+    let err = served_dir.get("/subdir", &hdrs).await.unwrap_err();
+    match err {
+        SerdirError::IOError(inner) => {
+            assert_eq!(inner.kind(), std::io::ErrorKind::Other);
+            assert_eq!(inner.to_string(), "hash calculation failed");
+        }
+        other => panic!("expected IOError, got {:?}", other),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_served_dir_hash_function_error_with_static_compression() {
+    let context = TestContext::new();
+    context.write_file("test.txt", "raw content");
+    context.write_file("test.txt.gz", "fake gzip content");
+
+    let served_dir = context
+        .builder
+        .static_compression(false, true, false)
+        .file_hasher(hash_error)
+        .build();
+    let mut hdrs = HeaderMap::new();
+    hdrs.insert(header::ACCEPT_ENCODING, HeaderValue::from_static("gzip"));
+
+    let err = served_dir.get("/test.txt", &hdrs).await.unwrap_err();
+    match err {
+        SerdirError::IOError(inner) => {
+            assert_eq!(inner.kind(), std::io::ErrorKind::Other);
+            assert_eq!(inner.to_string(), "hash calculation failed");
+        }
+        other => panic!("expected IOError, got {:?}", other),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_served_dir_hash_function_error_with_resource_cache() {
+    let context = TestContext::new();
+    context.write_file("data.txt", "original content");
+
+    let cache_settings = CacheSettings::new()
+        .max_total_weight(1024)
+        .max_item_weight(1024);
+
+    let served_dir = context
+        .builder
+        .cache_resources(cache_settings)
+        .file_hasher(hash_error)
+        .build();
+    let hdrs = HeaderMap::new();
+
+    let err = served_dir.get("/data.txt", &hdrs).await.unwrap_err();
+    match err {
+        SerdirError::IOError(inner) => {
+            assert_eq!(inner.kind(), std::io::ErrorKind::Other);
+            assert_eq!(inner.to_string(), "hash calculation failed");
+        }
+        other => panic!("expected IOError, got {:?}", other),
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap for handling `ResourceHasher` errors in `ServedDir` was incomplete. There was only one basic test, and it lacked coverage for how this error propagates through other `ServedDirBuilder` configurations.
📊 **Coverage:** Added tests to cover a custom file hasher returning an error when:
- `append_index_html` is enabled.
- `static_compression` is enabled (for an existing compressed variant).
- `cache_resources` is configured.
✨ **Result:** The improvement in test coverage guarantees that `SerdirError::IOError` is reliably bubbled up and not swallowed, regardless of the features enabled in the builder, thereby preventing silent ETag generation failures.

---
*PR created automatically by Jules for task [8816648258964927301](https://jules.google.com/task/8816648258964927301) started by @StupendousYappi*